### PR TITLE
Fix code scanning alert no. 2: Disabled Spring CSRF protection

### DIFF
--- a/jhipster-task-app/src/main/java/com/dv/ipsum/config/SecurityConfiguration.java
+++ b/jhipster-task-app/src/main/java/com/dv/ipsum/config/SecurityConfiguration.java
@@ -48,7 +48,7 @@ public class SecurityConfiguration {
     public SecurityFilterChain filterChain(HttpSecurity http, MvcRequestMatcher.Builder mvc) throws Exception {
         http
             .cors(withDefaults())
-            .csrf(csrf -> csrf.disable())
+            .csrf(withDefaults())
             .addFilterAfter(new SpaWebFilter(), BasicAuthenticationFilter.class)
             .headers(
                 headers ->


### PR DESCRIPTION
Fixes [https://github.com/Hostilian/dvtask/security/code-scanning/2](https://github.com/Hostilian/dvtask/security/code-scanning/2)

To fix the issue, we need to enable CSRF protection in the `SecurityConfiguration` class. This involves removing the line that disables CSRF protection and ensuring that the default CSRF protection provided by Spring Security is active.

- **General Fix**: Remove the `csrf.disable()` call to ensure that CSRF protection is enabled.
- **Detailed Fix**: In the `filterChain` method of the `SecurityConfiguration` class, remove or comment out the line `csrf.disable()`.
- **Specific Changes**: Modify the `filterChain` method in the `SecurityConfiguration` class to remove the disabling of CSRF protection.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
